### PR TITLE
Convert style object to style string

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,7 +26,7 @@ const description = "We build things for creators.";
           class="flex flex-col items-center min-h-screen animate-fade-in-down text-gray-800 relative">
           <div
             class="flex flex-col justify-center items-center py-8 px-4 w-full shadow-xl bg-gray-900 bg-gradient-to-tr from-gray-900 to-gray-800 text-gray-200"
-            style={{ fontFamily: "Inter" }}>
+            style="font-family: Inter">
             <img
               src={"/assets/t3-block.svg"}
               class="rounded-xl"


### PR DESCRIPTION
Found a small error in your style attribute that was causing this on the frontend:

```
<div 
  class="flex flex-col justify-center items-center py-8 px-4 w-full shadow-xl bg-gray-900 bg-gradient-to-tr from-gray-900 to-gray-800 text-gray-200" 
  style="[object Object]"
>
```

We should definitely be erroring or allowing this, instead of silently converting to an `[object Object]` string. But for now, attributes in `.astro` are required to be strings.