### PR TITLE
Sponsor page overhaul, homepage tidy up, footer fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ yarn-error.log*
 .DS_Store
 
 .astro
+.gstack/

--- a/src/components/SponsorCard.astro
+++ b/src/components/SponsorCard.astro
@@ -1,0 +1,151 @@
+---
+import SponsorLogo from "./SponsorLogo.astro";
+import { formatSponsorCategory, type SponsorEntry } from "../lib/sponsors";
+
+interface Props {
+  sponsor: SponsorEntry;
+  variant?: "default" | "platinum" | "gold" | "silver";
+}
+
+const { sponsor, variant = "default" } = Astro.props;
+
+const categoryLabels = sponsor.categories.map(formatSponsorCategory);
+const searchableText = [
+  sponsor.name,
+  sponsor.description,
+  sponsor.kind,
+  sponsor.tier ?? "",
+  ...categoryLabels,
+]
+  .join(" ")
+  .toLowerCase();
+
+const isPlatinum = variant === "platinum";
+const isGold = variant === "gold";
+const isSilver = variant === "silver";
+const isDefault = variant === "default";
+---
+
+<article
+  data-sponsor-card
+  data-kind={sponsor.kind}
+  data-tier={sponsor.tier ?? ""}
+  data-categories={sponsor.categories.join(",")}
+  data-search={searchableText}
+>
+  {
+    isPlatinum ? (
+      <a
+        href={`/sponsors/${sponsor.slug}`}
+        class="sponsor-card-platinum group flex h-full flex-col items-center rounded-2xl p-6 text-center md:p-8"
+      >
+        <div class="relative mb-5">
+          <div
+            class="absolute -inset-4 rounded-full bg-cyan-400/10 blur-2xl"
+            aria-hidden="true"
+          />
+          <SponsorLogo
+            image={sponsor.image}
+            name={sponsor.name}
+            class="relative size-16 md:size-20"
+          />
+        </div>
+
+        <h3 class="text-text text-xl font-medium tracking-tight md:text-2xl">
+          {sponsor.name}
+        </h3>
+        <p class="text-muted mt-2 max-w-xs text-sm leading-relaxed md:text-base">
+          {sponsor.description}
+        </p>
+
+        <div class="mt-4 flex flex-wrap justify-center gap-1.5">
+          {categoryLabels.map((label) => (
+            <span class="rounded-full bg-cyan-400/[0.08] px-2.5 py-0.5 text-[10px] tracking-wider text-cyan-300/50 uppercase">
+              {label}
+            </span>
+          ))}
+        </div>
+      </a>
+    ) : (
+      <a
+        href={`/sponsors/${sponsor.slug}`}
+        class:list={[
+          "group flex h-full flex-col rounded-2xl transition-all duration-300",
+          isGold &&
+            "border border-gold/20 bg-gradient-to-br from-gold/[0.06] via-surface/80 to-surface/50 p-5 hover:border-gold/35 hover:shadow-[0_0_40px_-12px_rgba(212,168,83,0.25)] md:p-6",
+          isSilver &&
+            "border border-silver/15 bg-gradient-to-br from-silver/[0.04] via-surface/80 to-surface/50 p-4 hover:border-silver/25 hover:shadow-[0_0_30px_-12px_rgba(148,163,184,0.2)] md:p-5",
+          isDefault &&
+            "border border-white/5 bg-surface/50 p-4 hover:border-white/10 hover:bg-surface",
+        ]}
+      >
+        <div
+          class:list={[
+            "flex min-w-0 flex-1 gap-4",
+            isGold ? "items-start md:gap-5" : "items-start",
+          ]}
+        >
+          <SponsorLogo
+            image={sponsor.image}
+            name={sponsor.name}
+            class:list={[
+              "shrink-0",
+              isGold && "size-12 md:size-14",
+              isSilver && "size-10 md:size-12",
+              isDefault && "size-10",
+            ]}
+          />
+          <div class="min-w-0 flex-1">
+            <div class="flex flex-wrap items-center gap-2">
+              <h3
+                class:list={[
+                  "text-text font-medium tracking-tight",
+                  isGold && "text-base md:text-lg",
+                  (isSilver || isDefault) && "text-sm",
+                ]}
+              >
+                {sponsor.name}
+              </h3>
+              {sponsor.kind === "affiliate" && (
+                <span class="text-subtle rounded-full border border-white/10 px-2 py-0.5 text-[10px] tracking-wider uppercase">
+                  affiliate
+                </span>
+              )}
+            </div>
+
+            <p
+              class:list={[
+                "text-muted leading-relaxed",
+                isGold && "mt-2 text-sm",
+                isSilver && "mt-1.5 text-xs leading-5",
+                isDefault && "mt-1 text-xs leading-5",
+              ]}
+            >
+              {sponsor.description}
+            </p>
+
+            <div
+              class:list={[
+                "flex flex-wrap gap-1.5",
+                isGold ? "mt-3" : "mt-2.5",
+              ]}
+            >
+              {categoryLabels.map((label) => (
+                <span
+                  class:list={[
+                    "rounded-full px-2 py-0.5 text-[10px] tracking-wider uppercase",
+                    isGold && "bg-gold/[0.08] text-gold/50",
+                    isSilver && "bg-silver/[0.08] text-silver/50",
+                    isDefault && "bg-white/[0.05] text-muted",
+                  ]}
+                >
+                  {label}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      </a>
+    )
+  }
+</article>

--- a/src/components/SponsorCard.astro
+++ b/src/components/SponsorCard.astro
@@ -4,7 +4,7 @@ import { formatSponsorCategory, type SponsorEntry } from "../lib/sponsors";
 
 interface Props {
   sponsor: SponsorEntry;
-  variant?: "default" | "platinum" | "platinum-featured" | "gold" | "silver";
+  variant?: "default" | "platinum" | "platinum-featured" | "gold" | "silver" | "new";
 }
 
 const { sponsor, variant = "default" } = Astro.props;
@@ -24,6 +24,7 @@ const isPlatinumFeatured = variant === "platinum-featured";
 const isPlatinum = variant === "platinum";
 const isGold = variant === "gold";
 const isSilver = variant === "silver";
+const isNew = variant === "new";
 const isDefault = variant === "default";
 ---
 
@@ -88,6 +89,8 @@ const isDefault = variant === "default";
             "border border-gold/20 bg-gradient-to-br from-gold/[0.06] via-surface/80 to-surface/50 p-5 hover:border-gold/35 hover:shadow-[0_0_40px_-12px_rgba(212,168,83,0.25)] md:p-6",
           isSilver &&
             "border border-silver/15 bg-gradient-to-br from-silver/[0.04] via-surface/80 to-surface/50 p-4 hover:border-silver/25 hover:shadow-[0_0_30px_-12px_rgba(148,163,184,0.2)] md:p-5",
+          isNew &&
+            "border border-emerald-400/15 bg-gradient-to-br from-emerald-400/[0.04] via-surface/80 to-surface/50 p-4 hover:border-emerald-400/25 hover:shadow-[0_0_30px_-12px_rgba(52,211,153,0.2)] md:p-5",
           isDefault &&
             "border border-white/5 bg-surface/50 p-4 hover:border-white/10 hover:bg-surface",
         ]}
@@ -105,6 +108,7 @@ const isDefault = variant === "default";
               "shrink-0",
               isGold && "size-12 md:size-14",
               isSilver && "size-10 md:size-12",
+              isNew && "size-10 md:size-12",
               isDefault && "size-10",
             ]}
           />
@@ -114,7 +118,7 @@ const isDefault = variant === "default";
                 class:list={[
                   "text-text font-medium tracking-tight",
                   isGold && "text-base md:text-lg",
-                  (isSilver || isDefault) && "text-sm",
+                  (isSilver || isNew || isDefault) && "text-sm",
                 ]}
               >
                 {sponsor.name}
@@ -131,6 +135,7 @@ const isDefault = variant === "default";
                 "text-muted leading-relaxed",
                 isGold && "mt-2 text-sm",
                 isSilver && "mt-1.5 text-xs leading-5",
+                isNew && "mt-1.5 text-xs leading-5",
                 isDefault && "mt-1 text-xs leading-5",
               ]}
             >
@@ -149,6 +154,7 @@ const isDefault = variant === "default";
                     "rounded-full px-2 py-0.5 text-[10px] tracking-wider uppercase",
                     isGold && "bg-gold/[0.08] text-gold/50",
                     isSilver && "bg-silver/[0.08] text-silver/50",
+                    isNew && "bg-emerald-400/[0.08] text-emerald-400/50",
                     isDefault && "bg-white/[0.05] text-muted",
                   ]}
                 >

--- a/src/components/SponsorCard.astro
+++ b/src/components/SponsorCard.astro
@@ -4,7 +4,7 @@ import { formatSponsorCategory, type SponsorEntry } from "../lib/sponsors";
 
 interface Props {
   sponsor: SponsorEntry;
-  variant?: "default" | "platinum" | "gold" | "silver";
+  variant?: "default" | "platinum" | "platinum-featured" | "gold" | "silver";
 }
 
 const { sponsor, variant = "default" } = Astro.props;
@@ -20,6 +20,7 @@ const searchableText = [
   .join(" ")
   .toLowerCase();
 
+const isPlatinumFeatured = variant === "platinum-featured";
 const isPlatinum = variant === "platinum";
 const isGold = variant === "gold";
 const isSilver = variant === "silver";
@@ -34,12 +35,22 @@ const isDefault = variant === "default";
   data-search={searchableText}
 >
   {
-    isPlatinum ? (
+    isPlatinumFeatured ? (
+      /* unused - keeping for type compatibility */
       <a
         href={`/sponsors/${sponsor.slug}`}
-        class="sponsor-card-platinum group flex h-full flex-col items-center rounded-2xl p-6 text-center md:p-8"
+        class="sponsor-card-platinum group flex h-full flex-col items-center rounded-2xl p-6 text-center md:p-7"
       >
-        <div class="relative mb-5">
+        <SponsorLogo image={sponsor.image} name={sponsor.name} class="size-16" />
+        <h3 class="text-text mt-4 text-xl font-medium">{sponsor.name}</h3>
+        <p class="text-muted mt-2 text-sm">{sponsor.description}</p>
+      </a>
+    ) : isPlatinum ? (
+      <a
+        href={`/sponsors/${sponsor.slug}`}
+        class="sponsor-card-platinum group flex h-full items-start gap-5 rounded-2xl p-6 md:gap-6 md:p-8"
+      >
+        <div class="relative shrink-0">
           <div
             class="absolute -inset-4 rounded-full bg-cyan-400/10 blur-2xl"
             aria-hidden="true"
@@ -47,23 +58,25 @@ const isDefault = variant === "default";
           <SponsorLogo
             image={sponsor.image}
             name={sponsor.name}
-            class="relative size-16 md:size-20"
+            class="relative size-14 md:size-16"
           />
         </div>
 
-        <h3 class="text-text text-xl font-medium tracking-tight md:text-2xl">
-          {sponsor.name}
-        </h3>
-        <p class="text-muted mt-2 max-w-xs text-sm leading-relaxed md:text-base">
-          {sponsor.description}
-        </p>
+        <div class="flex min-w-0 flex-1 flex-col">
+          <h3 class="text-text text-lg font-medium tracking-tight md:text-xl">
+            {sponsor.name}
+          </h3>
+          <p class="text-muted mt-2 text-sm leading-relaxed">
+            {sponsor.description}
+          </p>
 
-        <div class="mt-4 flex flex-wrap justify-center gap-1.5">
-          {categoryLabels.map((label) => (
-            <span class="rounded-full bg-cyan-400/[0.08] px-2.5 py-0.5 text-[10px] tracking-wider text-cyan-300/50 uppercase">
-              {label}
-            </span>
-          ))}
+          <div class="mt-4 flex flex-wrap gap-1.5">
+            {categoryLabels.map((label) => (
+              <span class="rounded-full bg-cyan-400/[0.08] px-2.5 py-0.5 text-[10px] tracking-wider text-cyan-300/50 uppercase">
+                {label}
+              </span>
+            ))}
+          </div>
         </div>
       </a>
     ) : (

--- a/src/components/SponsorGridSection.astro
+++ b/src/components/SponsorGridSection.astro
@@ -7,7 +7,7 @@ interface Props {
   heading: string;
   sponsors: SponsorEntry[];
   class?: string;
-  variant?: "default" | "platinum" | "platinum-featured" | "gold" | "silver";
+  variant?: "default" | "platinum" | "platinum-featured" | "gold" | "silver" | "new";
 }
 
 const {
@@ -21,6 +21,7 @@ const {
 const isPlatinum = variant === "platinum";
 const isGold = variant === "gold";
 const isSilver = variant === "silver";
+const isNew = variant === "new";
 const isDefault = variant === "default";
 ---
 
@@ -74,6 +75,22 @@ const isDefault = variant === "default";
           />
         </div>
       </div>
+    ) : isNew ? (
+      <div class="mb-6">
+        <div class="flex items-center gap-3">
+          <span
+            class="inline-block size-1.5 rounded-full bg-emerald-400"
+            aria-hidden="true"
+          />
+          <h2 class="text-emerald-400 text-sm font-medium tracking-wider uppercase">
+            {heading}
+          </h2>
+          <div
+            class="h-px flex-1 bg-gradient-to-r from-emerald-400/20 to-transparent"
+            aria-hidden="true"
+          />
+        </div>
+      </div>
     ) : (
       <div class="mb-6">
         <h2 class="text-muted text-sm tracking-wider uppercase">{heading}</h2>
@@ -88,6 +105,7 @@ const isDefault = variant === "default";
       isPlatinum && "gap-6 md:grid-cols-2",
       isGold && "gap-5 md:grid-cols-2 lg:gap-6",
       isSilver && "gap-4 md:grid-cols-2 lg:grid-cols-3",
+      isNew && "gap-4 md:grid-cols-2 lg:grid-cols-3",
       isDefault && "gap-3 md:grid-cols-2 lg:grid-cols-3",
     ]}
   >

--- a/src/components/SponsorGridSection.astro
+++ b/src/components/SponsorGridSection.astro
@@ -86,7 +86,7 @@ const isDefault = variant === "default";
     class:list={[
       "grid grid-cols-1",
       isPlatinum && "gap-6 md:grid-cols-2",
-      isGold && "gap-5 md:grid-cols-2 lg:grid-cols-3 lg:gap-6",
+      isGold && "gap-5 md:grid-cols-2 lg:gap-6",
       isSilver && "gap-4 md:grid-cols-2 lg:grid-cols-3",
       isDefault && "gap-3 md:grid-cols-2 lg:grid-cols-3",
     ]}

--- a/src/components/SponsorGridSection.astro
+++ b/src/components/SponsorGridSection.astro
@@ -1,63 +1,92 @@
 ---
-const sponsorImages = import.meta.glob<any>("../assets/sponsors/*.svg.astro");
+import SponsorCard from "./SponsorCard.astro";
+import type { SponsorEntry } from "../lib/sponsors";
 
 interface Props {
+  id?: string;
   heading: string;
-  sponsors: {
-    name: string;
-    link: string;
-    image: string;
-    description: string;
-  }[];
+  sponsors: SponsorEntry[];
   class?: string;
+  variant?: "default" | "platinum" | "gold" | "silver";
 }
 
-const { heading, sponsors, class: className } = Astro.props;
+const {
+  id,
+  heading,
+  sponsors,
+  class: className,
+  variant = "default",
+} = Astro.props;
+
+const isPlatinum = variant === "platinum";
+const isGold = variant === "gold";
+const isSilver = variant === "silver";
+const isDefault = variant === "default";
 ---
 
-<section class={className}>
-  <h2 class="text-muted mb-6 text-sm tracking-wider">{heading}</h2>
-  <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-    {
-      sponsors.map(async (brand) => {
-        const imageImporter =
-          sponsorImages[`../assets/sponsors/${brand.image}`];
+<section id={id} data-sponsor-section class={className}>
+  {
+    isPlatinum ? (
+      <div class="mb-8 border-b border-cyan-400/10 pb-6">
+        <p class="text-accent mb-2 text-[10px] tracking-[0.25em] uppercase">
+          platinum tier
+        </p>
+        <h2 class="text-text text-2xl font-medium tracking-tight capitalize md:text-3xl">
+          {heading}
+        </h2>
+        <p class="text-muted mt-2 max-w-xl text-sm leading-relaxed">
+          partners running the biggest integrations on the channel right now.
+        </p>
+      </div>
+    ) : isGold ? (
+      <div class="mb-6">
+        <div class="flex items-center gap-3">
+          <span
+            class="inline-block size-1.5 rounded-full bg-gold"
+            aria-hidden="true"
+          />
+          <h2 class="text-gold text-sm font-medium tracking-wider uppercase">
+            {heading}
+          </h2>
+          <div
+            class="h-px flex-1 bg-gradient-to-r from-gold/20 to-transparent"
+            aria-hidden="true"
+          />
+        </div>
+      </div>
+    ) : isSilver ? (
+      <div class="mb-6">
+        <div class="flex items-center gap-3">
+          <span
+            class="inline-block size-1.5 rounded-full bg-silver"
+            aria-hidden="true"
+          />
+          <h2 class="text-silver text-sm font-medium tracking-wider uppercase">
+            {heading}
+          </h2>
+          <div
+            class="h-px flex-1 bg-gradient-to-r from-silver/20 to-transparent"
+            aria-hidden="true"
+          />
+        </div>
+      </div>
+    ) : (
+      <div class="mb-6">
+        <h2 class="text-muted text-sm tracking-wider uppercase">{heading}</h2>
+      </div>
+    )
+  }
 
-        try {
-          const BrandImage = await imageImporter().then(
-            (mod) => mod.default || mod,
-          );
-
-          return (
-            <a
-              href={brand.link}
-              class="group bg-surface/50 hover:bg-surface flex flex-row items-center gap-4 rounded-lg border border-white/5 p-4 transition-all duration-200 hover:border-white/10"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <div
-                role="img"
-                aria-label={brand.name}
-                class="text-text flex size-12 shrink-0 items-center justify-center [&_svg]:size-full"
-              >
-                <BrandImage />
-              </div>
-              <div class="flex min-w-0 grow flex-col">
-                <h3 class="text-text text-sm font-medium">{brand.name}</h3>
-                <p class="text-muted mt-0.5 line-clamp-2 text-xs">
-                  {brand.description}
-                </p>
-              </div>
-            </a>
-          );
-        } catch (error) {
-          console.error(
-            `Failed to load image component for ${brand.image}:`,
-            error,
-          );
-          return null;
-        }
-      })
-    }
+  <div
+    data-sponsor-grid
+    class:list={[
+      "grid grid-cols-1",
+      isPlatinum && "gap-6 md:grid-cols-2 lg:grid-cols-3 lg:gap-8",
+      isGold && "gap-5 md:grid-cols-2 lg:grid-cols-3 lg:gap-6",
+      isSilver && "gap-4 md:grid-cols-2 lg:grid-cols-3",
+      isDefault && "gap-3 md:grid-cols-2 lg:grid-cols-3",
+    ]}
+  >
+    {sponsors.map((brand) => <SponsorCard sponsor={brand} variant={variant} />)}
   </div>
 </section>

--- a/src/components/SponsorGridSection.astro
+++ b/src/components/SponsorGridSection.astro
@@ -7,7 +7,7 @@ interface Props {
   heading: string;
   sponsors: SponsorEntry[];
   class?: string;
-  variant?: "default" | "platinum" | "gold" | "silver";
+  variant?: "default" | "platinum" | "platinum-featured" | "gold" | "silver";
 }
 
 const {
@@ -27,16 +27,20 @@ const isDefault = variant === "default";
 <section id={id} data-sponsor-section class={className}>
   {
     isPlatinum ? (
-      <div class="mb-8 border-b border-cyan-400/10 pb-6">
-        <p class="text-accent mb-2 text-[10px] tracking-[0.25em] uppercase">
-          platinum tier
-        </p>
-        <h2 class="text-text text-2xl font-medium tracking-tight capitalize md:text-3xl">
-          {heading}
-        </h2>
-        <p class="text-muted mt-2 max-w-xl text-sm leading-relaxed">
-          partners running the biggest integrations on the channel right now.
-        </p>
+      <div class="mb-8">
+        <div class="flex items-center gap-3">
+          <span
+            class="inline-block size-1.5 rounded-full bg-accent"
+            aria-hidden="true"
+          />
+          <h2 class="text-accent text-sm font-medium tracking-wider uppercase">
+            {heading}
+          </h2>
+          <div
+            class="h-px flex-1 bg-gradient-to-r from-cyan-400/20 to-transparent"
+            aria-hidden="true"
+          />
+        </div>
       </div>
     ) : isGold ? (
       <div class="mb-6">
@@ -81,7 +85,7 @@ const isDefault = variant === "default";
     data-sponsor-grid
     class:list={[
       "grid grid-cols-1",
-      isPlatinum && "gap-6 md:grid-cols-2 lg:grid-cols-3 lg:gap-8",
+      isPlatinum && "gap-6 md:grid-cols-2",
       isGold && "gap-5 md:grid-cols-2 lg:grid-cols-3 lg:gap-6",
       isSilver && "gap-4 md:grid-cols-2 lg:grid-cols-3",
       isDefault && "gap-3 md:grid-cols-2 lg:grid-cols-3",

--- a/src/components/SponsorLogo.astro
+++ b/src/components/SponsorLogo.astro
@@ -1,0 +1,39 @@
+---
+const sponsorImages = import.meta.glob<any>("../assets/sponsors/*.svg.astro");
+
+interface Props {
+  image: string;
+  name: string;
+  class?: string;
+}
+
+const { image, name, class: className } = Astro.props;
+
+const imageImporter = sponsorImages[`../assets/sponsors/${image}`];
+
+let BrandImage: any = null;
+
+if (imageImporter) {
+  const imageModule = await imageImporter();
+  BrandImage = imageModule.default || imageModule;
+}
+---
+
+<div
+  role="img"
+  aria-label={name}
+  class:list={[
+    "text-text flex shrink-0 items-center justify-center [&_svg]:size-full",
+    className ?? "size-12",
+  ]}
+>
+  {
+    BrandImage ? (
+      <BrandImage />
+    ) : (
+      <span class="text-muted text-[10px] font-medium tracking-wider uppercase">
+        {name}
+      </span>
+    )
+  }
+</div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -63,7 +63,8 @@ const isHomepage = Astro.url.pathname === "/";
     <meta property="og:image" content="https://t3.gg/images/twitter.png" />
     <title>{title}</title>
     <meta name="theme-color" content="#050505" />
-    <script defer data-domain="astro.t3.gg" src="/js/script.js"></script>
+    <script is:inline defer data-domain="astro.t3.gg" src="/js/script.js"
+    ></script>
   </head>
   <body
     class={cn(

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,6 +7,7 @@ import LeftArrow from "../assets/icons/left-arrow.svg.astro";
 const socialLinks = [
   { href: "https://github.com/t3dotgg", label: "gh" },
   { href: "https://twitter.com/theo", label: "x" },
+  { href: "https://youtube.com/@t3dotgg", label: "yt" },
   { href: "https://twitch.tv/theo", label: "twitch" },
   { href: "https://discord.gg/xHdCpcPHRE", label: "discord" },
 ];
@@ -62,8 +63,7 @@ const isHomepage = Astro.url.pathname === "/";
     <meta property="og:image" content="https://t3.gg/images/twitter.png" />
     <title>{title}</title>
     <meta name="theme-color" content="#050505" />
-    <script is:inline defer data-domain="astro.t3.gg" src="/js/script.js"
-    ></script>
+    <script defer data-domain="astro.t3.gg" src="/js/script.js"></script>
   </head>
   <body
     class={cn(
@@ -71,14 +71,16 @@ const isHomepage = Astro.url.pathname === "/";
       classNames?.body,
     )}
   >
-    <main class={cn("flex min-h-screen flex-col text-text", classNames?.main)}>
+    <main
+      class={cn("flex flex-col text-text", classNames?.main)}
+    >
       <slot />
       {
         !isHomepage && backToLink && (
           <aside class="mb-8 text-center">
             <a
               href={backToLink.href}
-              class="group text-muted hover:text-text mt-8 -mb-4 inline-flex items-center justify-center gap-2 p-2 transition-colors duration-200"
+              class="group mt-8 -mb-4 inline-flex items-center justify-center gap-2 p-2 text-muted transition-colors duration-200 hover:text-text"
             >
               <LeftArrow class="transition-transform duration-200 group-hover:-translate-x-0.5" />
               <span class="text-sm tracking-wide">{backToLink.text}</span>
@@ -86,32 +88,32 @@ const isHomepage = Astro.url.pathname === "/";
           </aside>
         )
       }
-      <footer
-        class={cn(
-          "[--space:--spacing(6)] sm:[--space:--spacing(10)]",
-          "border-t border-white/5 pt-(--space) pb-safe-offset-(--space)",
-          classNames?.footer,
-        )}
-      >
-        <div class="container mx-auto px-4">
-          <div
-            class="flex w-full items-center justify-center gap-x-6 text-sm tracking-wider"
+      {
+        !isHomepage && (
+          <footer
+            class={cn(
+              "[--space:--spacing(6)] sm:[--space:--spacing(10)]",
+              "border-t border-white/5 pt-(--space) pb-safe-offset-(--space) mb-8",
+              classNames?.footer,
+            )}
           >
-            {
-              socialLinks.map((link) => (
-                <a
-                  href={link.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="text-muted hover:text-text transition-colors duration-200"
-                >
-                  {link.label}
-                </a>
-              ))
-            }
-          </div>
-        </div>
-      </footer>
+            <div class="container mx-auto px-4">
+              <div class="flex w-full items-center justify-center gap-x-6 text-sm tracking-wider">
+                {socialLinks.map((link) => (
+                  <a
+                    href={link.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-muted transition-colors duration-200 hover:text-text"
+                  >
+                    {link.label}
+                  </a>
+                ))}
+              </div>
+            </div>
+          </footer>
+        )
+      }
     </main>
   </body>
 </html>

--- a/src/lib/sponsors.ts
+++ b/src/lib/sponsors.ts
@@ -25,16 +25,10 @@ export const sponsorCategoryOptions = [
 export type SponsorCategory = (typeof sponsorCategoryOptions)[number]["slug"];
 export type SponsorKind = "sponsor" | "affiliate";
 
-export interface SponsorPageSection {
-  heading: string;
-  content: string;
-}
-
 export interface SponsorPageContent {
   seoTitle: string;
   seoDescription: string;
   intro: string;
-  bodySections: SponsorPageSection[];
   primaryCtaLabel: string;
 }
 
@@ -64,7 +58,7 @@ type SponsorSeed = {
   categories: SponsorCategory[];
   tier?: SponsorTier | null;
   slug?: string;
-  page?: Partial<SponsorPageContent>;
+  page?: Partial<Pick<SponsorPageContent, "seoTitle" | "seoDescription" | "intro" | "primaryCtaLabel">>;
 };
 
 const sponsorCategoryLabelMap = Object.fromEntries(
@@ -74,18 +68,6 @@ const sponsorCategoryLabelMap = Object.fromEntries(
 const sponsorKindLabelMap: Record<SponsorKind, string> = {
   sponsor: "video sponsor",
   affiliate: "affiliate deal",
-};
-
-const formatList = (values: string[]) => {
-  if (values.length <= 1) {
-    return values[0] ?? "";
-  }
-
-  if (values.length === 2) {
-    return `${values[0]} and ${values[1]}`;
-  }
-
-  return `${values.slice(0, -1).join(", ")}, and ${values.at(-1)}`;
 };
 
 const buildSlug = (brand: SponsorSeed) => {
@@ -104,14 +86,7 @@ const buildSponsorPage = (
   brand: SponsorSeed,
   kind: SponsorKind,
 ): SponsorPageContent => {
-  const categoryLabels = brand.categories.map(formatSponsorCategory);
-  const categorySummary = formatList(categoryLabels);
   const kindLabel = sponsorKindLabelMap[kind];
-  const tierSummary = brand.tier
-    ? `it currently sits in theo's ${brand.tier} tier.`
-    : kind === "sponsor"
-      ? "it's listed in the past sponsors section here."
-      : "it currently lives in theo's broader sponsor directory.";
 
   return {
     seoTitle: brand.page?.seoTitle ?? `${brand.name} | sponsors`,
@@ -119,20 +94,6 @@ const buildSponsorPage = (
     intro:
       brand.page?.intro ??
       `${brand.name} is a ${kindLabel} on theo's site. ${brand.description}`,
-    bodySections: brand.page?.bodySections ?? [
-      {
-        heading: "overview",
-        content: brand.description,
-      },
-      {
-        heading: "where it fits",
-        content: `this is a good fit if you're looking at ${categorySummary}.`,
-      },
-      {
-        heading: "partnership",
-        content: `${brand.name} is listed here as a ${kindLabel}, and ${tierSummary}`,
-      },
-    ],
     primaryCtaLabel: brand.page?.primaryCtaLabel ?? `visit ${brand.name}`,
   };
 };
@@ -713,6 +674,7 @@ export const usedSponsorCategories = sponsorCategoryOptions.filter(
 export const getSponsorBySlug = (slug: string) => {
   return sponsorDirectory.find((brand) => brand.slug === slug);
 };
+
 
 const sponsorTierSlugOrder: Record<SponsorTier, string[]> = {
   platinum: ["workos", "blacksmith", "browserbase", "coderabbit"],

--- a/src/lib/sponsors.ts
+++ b/src/lib/sponsors.ts
@@ -1,17 +1,163 @@
-type Sponsor = {
+export const sponsorTierOrder = ["platinum", "gold", "silver"] as const;
+
+export type SponsorTier = (typeof sponsorTierOrder)[number];
+
+export const sponsorCategoryOptions = [
+  { slug: "ai", label: "ai" },
+  { slug: "analytics", label: "analytics" },
+  { slug: "auth", label: "auth" },
+  { slug: "communications", label: "communications" },
+  { slug: "data", label: "data" },
+  { slug: "deployment", label: "deployment" },
+  { slug: "design", label: "design" },
+  { slug: "developer-tools", label: "developer tools" },
+  { slug: "education", label: "education" },
+  { slug: "finance", label: "finance" },
+  { slug: "frontend", label: "frontend" },
+  { slug: "hiring", label: "hiring" },
+  { slug: "infrastructure", label: "infrastructure" },
+  { slug: "monitoring", label: "monitoring" },
+  { slug: "productivity", label: "productivity" },
+  { slug: "security", label: "security" },
+] as const;
+
+export type SponsorCategory = (typeof sponsorCategoryOptions)[number]["slug"];
+export type SponsorKind = "sponsor" | "affiliate";
+
+export interface SponsorPageSection {
+  heading: string;
+  content: string;
+}
+
+export interface SponsorPageContent {
+  seoTitle: string;
+  seoDescription: string;
+  intro: string;
+  bodySections: SponsorPageSection[];
+  primaryCtaLabel: string;
+}
+
+export interface SponsorEntry {
+  slug: string;
   name: string;
   image: string;
   description: string;
   link: string;
+  categories: SponsorCategory[];
+  tier: SponsorTier | null;
+  kind: SponsorKind;
+  page: SponsorPageContent;
+}
+
+export interface SponsorDirectorySection {
+  id: string;
+  heading: string;
+  sponsors: SponsorEntry[];
+}
+
+type SponsorSeed = {
+  name: string;
+  image: string;
+  description: string;
+  link: string;
+  categories: SponsorCategory[];
+  tier?: SponsorTier | null;
+  slug?: string;
+  page?: Partial<SponsorPageContent>;
 };
 
-export const affiliates = [
+const sponsorCategoryLabelMap = Object.fromEntries(
+  sponsorCategoryOptions.map(({ slug, label }) => [slug, label]),
+) as Record<SponsorCategory, string>;
+
+const sponsorKindLabelMap: Record<SponsorKind, string> = {
+  sponsor: "video sponsor",
+  affiliate: "affiliate deal",
+};
+
+const formatList = (values: string[]) => {
+  if (values.length <= 1) {
+    return values[0] ?? "";
+  }
+
+  if (values.length === 2) {
+    return `${values[0]} and ${values[1]}`;
+  }
+
+  return `${values.slice(0, -1).join(", ")}, and ${values.at(-1)}`;
+};
+
+const buildSlug = (brand: SponsorSeed) => {
+  return brand.slug ?? brand.image.replace(".svg.astro", "");
+};
+
+export const formatSponsorCategory = (category: SponsorCategory) => {
+  return sponsorCategoryLabelMap[category];
+};
+
+export const formatSponsorTier = (tier: SponsorTier) => {
+  return tier;
+};
+
+const buildSponsorPage = (
+  brand: SponsorSeed,
+  kind: SponsorKind,
+): SponsorPageContent => {
+  const categoryLabels = brand.categories.map(formatSponsorCategory);
+  const categorySummary = formatList(categoryLabels);
+  const kindLabel = sponsorKindLabelMap[kind];
+  const tierSummary = brand.tier
+    ? `it currently sits in theo's ${brand.tier} tier.`
+    : kind === "sponsor"
+      ? "it's listed in the past sponsors section here."
+      : "it currently lives in theo's broader sponsor directory.";
+
+  return {
+    seoTitle: brand.page?.seoTitle ?? `${brand.name} | sponsors`,
+    seoDescription: brand.page?.seoDescription ?? brand.description,
+    intro:
+      brand.page?.intro ??
+      `${brand.name} is a ${kindLabel} on theo's site. ${brand.description}`,
+    bodySections: brand.page?.bodySections ?? [
+      {
+        heading: "overview",
+        content: brand.description,
+      },
+      {
+        heading: "where it fits",
+        content: `this is a good fit if you're looking at ${categorySummary}.`,
+      },
+      {
+        heading: "partnership",
+        content: `${brand.name} is listed here as a ${kindLabel}, and ${tierSummary}`,
+      },
+    ],
+    primaryCtaLabel: brand.page?.primaryCtaLabel ?? `visit ${brand.name}`,
+  };
+};
+
+const defineSponsor = (kind: SponsorKind, brand: SponsorSeed): SponsorEntry => {
+  return {
+    slug: buildSlug(brand),
+    name: brand.name,
+    image: brand.image,
+    description: brand.description,
+    link: brand.link,
+    categories: brand.categories,
+    tier: brand.tier ?? null,
+    kind,
+    page: buildSponsorPage(brand, kind),
+  };
+};
+
+const affiliateSeeds: SponsorSeed[] = [
   {
     name: "frontend masters",
     image: "frontend-masters.svg.astro",
     description:
       "name's quite literal - learn frontend from the masters. courses from ryan carniato, primeagen, and many more.",
     link: "https://soydev.link/masters",
+    categories: ["education", "frontend"],
   },
   {
     name: "eight sleep",
@@ -19,6 +165,7 @@ export const affiliates = [
     description:
       "a watercooler for your bed. sounds stupid but i literally can't sleep without it.",
     link: "https://soydev.link/eightsleep",
+    categories: ["productivity"],
   },
   {
     name: "superhuman",
@@ -26,6 +173,7 @@ export const affiliates = [
     description:
       "if you do more than an hour of email a day, you should be on superhuman. works with gmail and outlook.",
     link: "https://soydev.link/superhuman",
+    categories: ["productivity"],
   },
   {
     name: "code crafters",
@@ -33,15 +181,17 @@ export const affiliates = [
     description:
       "learn by rebuilding, literally - one of their courses is recreating redis lol.",
     link: "https://soydev.link/codecrafters",
+    categories: ["education", "developer-tools"],
   },
-] satisfies Sponsor[];
+];
 
-export const sponsors = [
+const sponsorSeeds: SponsorSeed[] = [
   {
     name: "infinite red",
     image: "infinite-red.svg.astro",
     description: "the first people i call for react native help.",
     link: "https://soydev.link/infinitered",
+    categories: ["developer-tools", "frontend"],
   },
   {
     name: "sevalla",
@@ -49,6 +199,7 @@ export const sponsors = [
     description:
       "deploy anything (like vercel but for php, rails, go, whatever else).",
     link: "https://soydev.link/sevalla",
+    categories: ["deployment", "infrastructure"],
   },
   {
     name: "posthog",
@@ -56,12 +207,16 @@ export const sponsors = [
     description:
       '"All in one suite of product tools" - also the only analytics provider i don\'t hate. open source too!',
     link: "https://soydev.link/posthog",
+    categories: ["analytics", "developer-tools"],
+    tier: "silver",
   },
   {
     name: "coderabbit",
     image: "code-rabbit.svg.astro",
     description: "ai code review that doesn't suck.",
     link: "https://soydev.link/coderabbit",
+    categories: ["ai", "developer-tools"],
+    tier: "gold",
   },
   {
     name: "imagekit",
@@ -69,12 +224,15 @@ export const sponsors = [
     description:
       "the best way to optimize images. works with any storage provider (even urls).",
     link: "https://soydev.link/imagekit",
+    categories: ["developer-tools", "infrastructure"],
   },
   {
     name: "blacksmith",
     image: "blacksmith.svg.astro",
     description: "github actions but they're 2x faster and way cheaper.",
     link: "https://soydev.link/blacksmith",
+    categories: ["developer-tools", "infrastructure"],
+    tier: "platinum",
   },
   {
     name: "kilo",
@@ -82,30 +240,37 @@ export const sponsors = [
     description:
       "the open source ai coding agent for vscode that codes, architects, debugs, and much more.",
     link: "https://soydev.link/kilo",
+    categories: ["ai", "developer-tools"],
+    tier: "gold",
   },
   {
     name: "arcjet",
     image: "arcjet.svg.astro",
     description: "the security platform for the modern web.",
     link: "https://soydev.link/arcjet",
+    categories: ["security"],
+    tier: "silver",
   },
   {
     name: "vapi",
     image: "vapi.svg.astro",
     description: "add ai voice to your ai apps in minutes.",
     link: "https://soydev.link/vapi",
+    categories: ["ai", "communications"],
   },
   {
     name: "notion",
     image: "notion.svg.astro",
     description: "i literally couldn't run my channel without notion.",
     link: "https://soydev.link/notion",
+    categories: ["productivity"],
   },
   {
     name: "tuple",
     image: "tuple.svg.astro",
     description: "the best pair programming tool by far.",
     link: "https://soydev.link/tuple",
+    categories: ["developer-tools", "productivity"],
   },
   {
     name: "ag grid",
@@ -113,6 +278,7 @@ export const sponsors = [
     description:
       "if you've ever liked a grid on the internet, 90%+ chance it was ag grid.",
     link: "https://soydev.link/ag-grid",
+    categories: ["developer-tools", "frontend"],
   },
   {
     name: "convex",
@@ -120,18 +286,22 @@ export const sponsors = [
     description:
       "the missing half of your react app. full stack reactivity from db to component. open source and typesafe too!",
     link: "https://soydev.link/convex",
+    categories: ["data", "developer-tools"],
   },
   {
     name: "ahrefs",
     image: "ahrefs.svg.astro",
     description: "makes me feel like i don't suck at SEO.",
     link: "https://soydev.link/ahrefs",
+    categories: ["analytics"],
   },
   {
     name: "greptile",
     image: "greptile.svg.astro",
     description: "the most tasteful ai code review tool.",
     link: "https://soydev.link/greptile",
+    categories: ["ai", "developer-tools"],
+    tier: "gold",
   },
   {
     name: "zephyr cloud",
@@ -139,6 +309,7 @@ export const sponsors = [
     description:
       "micro-frontends suck to build. zephyr makes them suck much less. if you have more than 50 people working on your frontend, talk to them.",
     link: "https://soydev.link/zephyr",
+    categories: ["deployment", "frontend", "infrastructure"],
   },
   {
     name: "graphite",
@@ -146,6 +317,7 @@ export const sponsors = [
     description:
       "if github is slowing you down, graphite will speed you back up. better pr flows for fast moving teams (used by vercel, ramp, snowflake, brex and more)",
     link: "https://soydev.link/graphite",
+    categories: ["developer-tools", "productivity"],
   },
   {
     name: "g2i",
@@ -153,36 +325,45 @@ export const sponsors = [
     description:
       "stop hiring bad engineers. g2i will do real video interviews with hundreds of candidates to get you the best possible engineer in weeks.",
     link: "https://soydev.link/g2i",
+    categories: ["hiring"],
+    tier: "silver",
   },
   {
     name: "mobbin",
     image: "mobbin.svg.astro",
     description: "the best place to get design inspiration, just 10$ a month.",
     link: "https://soydev.link/mobbin",
+    categories: ["design"],
   },
   {
     name: "depot",
     image: "depot.svg.astro",
     description: "40x faster docker builds used by posthog and so many more.",
     link: "https://soydev.link/depot",
+    categories: ["developer-tools", "infrastructure"],
+    tier: "gold",
   },
   {
     name: "agentuity",
     image: "agentuity.svg.astro",
     description: "the best way to setup, run, and scale your ai agents.",
     link: "https://soydev.link/agentuity",
+    categories: ["ai", "infrastructure"],
   },
   {
     name: "chef by convex",
     image: "chef.svg.astro",
     description: "the ai app builder that actually gets backend.",
     link: "https://soydev.link/chef",
+    categories: ["ai", "data"],
+    slug: "chef-by-convex",
   },
   {
     name: "fondo",
     image: "fondo.svg.astro",
     description: "the best bookkeeping and tax filing for startups.",
     link: "https://soydev.link/fondo",
+    categories: ["finance"],
   },
   {
     name: "bolt.new",
@@ -190,12 +371,15 @@ export const sponsors = [
     description:
       "best way to start your next project. prompt away, pick whatever framework you like, edit right in the browser.",
     link: "https://soydev.link/bolt",
+    categories: ["ai", "developer-tools"],
   },
   {
     name: "clerk",
     image: "clerk.svg.astro",
     description: "the only auth solution i don't hate using.",
     link: "https://soydev.link/clerk",
+    categories: ["auth", "security"],
+    tier: "gold",
   },
   {
     name: "browserbase",
@@ -203,26 +387,30 @@ export const sponsors = [
     description:
       "web browser for your ai. prompt for parsing, dodge captchas, get data out of anything.",
     link: "https://soydev.link/browserbase",
+    categories: ["ai", "infrastructure"],
+    tier: "platinum",
   },
   {
     name: "unkey",
     image: "unkey.svg.astro",
     description: "add api keys to your service without going insane.",
     link: "https://soydev.link/unkey",
+    categories: ["developer-tools", "security"],
   },
-
   {
     name: "payload",
     image: "payload.svg.astro",
     description:
       "headless cms for next.js. like an admin panel for anything. open source too!",
     link: "https://soydev.link/payload",
+    categories: ["data", "developer-tools"],
   },
   {
     name: "singlestore",
     image: "singlestore.svg.astro",
     description: "the only db you'll ever need.",
     link: "https://soydev.link/singlestore",
+    categories: ["data", "infrastructure"],
   },
   {
     name: "fal",
@@ -230,18 +418,23 @@ export const sponsors = [
     description:
       "ai apis for generating anything. if you want to add image/video/audio gen to your app, start here.",
     link: "https://soydev.link/fal",
+    categories: ["ai"],
   },
   {
     name: "workos",
     image: "workos.svg.astro",
     description: "the only sane way to handle enterprise auth.",
     link: "https://soydev.link/workos",
+    categories: ["auth", "security"],
+    tier: "platinum",
   },
   {
     name: "ragie ai",
     image: "ragie.svg.astro",
     description: "build apps using anything as a data source. i mean anything.",
     link: "https://soydev.link/ragie",
+    categories: ["ai", "data"],
+    slug: "ragie-ai",
   },
   {
     name: "agora",
@@ -249,18 +442,21 @@ export const sponsors = [
     description:
       "the only way i build webrtc into my apps. they have crazy voice ai stuff now too.",
     link: "https://soydev.link/agora",
+    categories: ["ai", "communications"],
   },
   {
     name: "bright data",
     image: "bright-data.svg.astro",
     description: "data proxy network for scraping the web.",
     link: "https://soydev.link/brightdata",
+    categories: ["data", "infrastructure"],
   },
   {
     name: "appwrite",
     image: "appwrite.svg.astro",
     description: "build your backend in hours, not months.",
     link: "https://soydev.link/appwrite",
+    categories: ["data", "developer-tools"],
   },
   {
     name: "highlight",
@@ -268,6 +464,7 @@ export const sponsors = [
     description:
       "telemetry and monitoring for your services - open source too.",
     link: "https://soydev.link/highlight",
+    categories: ["monitoring"],
   },
   {
     name: "netlify",
@@ -275,6 +472,7 @@ export const sponsors = [
     description:
       "deploy your frontend without compromise. scales forever. super fast. ai ready too :)",
     link: "https://soydev.link/netlify",
+    categories: ["deployment", "infrastructure"],
   },
   {
     name: "prisma postgres",
@@ -282,6 +480,8 @@ export const sponsors = [
     description:
       "probably the best way to deploy postgres rn, especially if you're building serverless.",
     link: "https://soydev.link/prismadb",
+    categories: ["data", "infrastructure"],
+    slug: "prisma-postgres",
   },
   {
     name: "dockyard",
@@ -289,18 +489,21 @@ export const sponsors = [
     description:
       "industry experts in all things elixir, hit them up if you need to scale.",
     link: "https://soydev.link/dockyard",
+    categories: ["developer-tools", "infrastructure"],
   },
   {
     name: "lovable",
     image: "lovable.svg.astro",
     description: "use ai to generate a lovable website.",
     link: "https://soydev.link/lovable",
+    categories: ["ai", "design"],
   },
   {
     name: "epic web",
     image: "epic-web.svg.astro",
     description: "the best react course ever made - by kent dodds.",
     link: "https://soydev.link/epicreact",
+    categories: ["education", "frontend"],
   },
   {
     name: "augment code",
@@ -308,30 +511,35 @@ export const sponsors = [
     description:
       "ai code assistant built for large codebases. works with vs code, jetbrains, and neovim.",
     link: "https://soydev.link/augmentcode",
+    categories: ["ai", "developer-tools"],
   },
   {
     name: "vercel",
     image: "vercel.svg.astro",
     description: "the first place i deploy things.",
     link: "https://soydev.link/vercel",
+    categories: ["deployment", "infrastructure"],
   },
   {
     name: "upstash",
     image: "upstash.svg.astro",
     description: "if i'm using redis, i'm probably using upstash for it.",
     link: "https://soydev.link/upstash",
+    categories: ["data", "infrastructure"],
   },
   {
     name: "planetscale",
     image: "planetscale.svg.astro",
     description: "mysql with superpowers.",
     link: "https://soydev.link/planetscale",
+    categories: ["data", "infrastructure"],
   },
   {
     name: "sentry",
     image: "sentry.svg.astro",
     description: "industry standard for error tracking.",
     link: "https://soydev.link/sentry",
+    categories: ["monitoring"],
   },
   {
     name: "axiom",
@@ -339,113 +547,212 @@ export const sponsors = [
     description:
       "the world's greatest log dump. they'll parse terabytes for you and give you a dashboard to see it all. wild.",
     link: "https://soydev.link/axiom",
+    categories: ["analytics", "monitoring"],
   },
   {
     name: "firecrawl",
     image: "firecrawl.svg.astro",
     description: "the best way to scape the web (that's also open source)",
     link: "https://soydev.link/firecrawl",
+    categories: ["ai", "data"],
   },
   {
     name: "embrace",
     image: "embrace.svg.astro",
     description: "web and mobile observability that's actually amazing",
     link: "https://soydev.link/embrace",
+    categories: ["monitoring"],
   },
   {
     name: "exa",
     image: "exa.svg.astro",
     description: "the only sane way to let your agents search the web",
     link: "https://soydev.link/exa",
+    categories: ["ai", "data"],
   },
   {
     name: "daytona",
     image: "daytona.svg.astro",
     description: "the place where you let agents run their code",
     link: "https://soydev.link/daytona",
+    categories: ["ai", "infrastructure"],
   },
   {
     name: "rork",
     image: "rork.svg.astro",
     description: "the vibe coding platform that actually gets react native",
     link: "https://soydev.link/rork",
+    categories: ["ai", "frontend"],
   },
   {
     name: "modal",
     image: "modal.svg.astro",
     description: "gpus, sandboxes, and more for your ai apps",
     link: "https://soydev.link/modal",
+    categories: ["ai", "infrastructure"],
   },
   {
     name: "factory",
     image: "factory.svg.astro",
     description: "coding agents in your cli, browser, editor, and more.",
     link: "https://soydev.link/factory",
+    categories: ["ai", "developer-tools"],
   },
   {
     name: "spacetimedb",
     image: "spacetime.svg.astro",
     description: "the most powerful fullstack database i've ever seen",
     link: "https://soydev.link/spacetime",
+    categories: ["data", "developer-tools"],
   },
   {
     name: "deepsource",
     image: "deepsource.svg.astro",
     description: "easily secure your entire development lifecycle",
     link: "https://soydev.link/deepsource",
+    categories: ["developer-tools", "security"],
+  },
+  {
+    name: "jfrog fly",
+    image: "jfrog.svg.astro",
+    description: "artifact management that's built for your ai agents",
+    link: "https://soydev.link/jfrogfly",
+    categories: ["developer-tools", "infrastructure"],
+    slug: "jfrog-fly",
   },
   {
     name: "wispr flow",
     image: "wispr.svg.astro",
     description: "the voice to text product that i can't live without",
-    link: "https://soydev.link/wisprflow",
+    link: "https://soydev.link/wispr",
+    categories: ["productivity"],
+    slug: "wispr-flow",
   },
   {
     name: "dnsimple",
     image: "dnsimple.svg.astro",
     description: "the best way to manage your domains and dns",
     link: "https://soydev.link/dnsimple",
+    categories: ["deployment", "infrastructure"],
   },
   {
     name: "railway",
     image: "railway.svg.astro",
     description: "the modern hosting solution with actual servers",
     link: "https://soydev.link/railway",
+    categories: ["deployment", "infrastructure"],
   },
   {
     name: "rwx",
     image: "rwx.svg.astro",
     description: "the best modern ci/cd for teams that actually ship",
     link: "https://soydev.link/rwx",
+    categories: ["deployment", "developer-tools"],
   },
   {
     name: "kernel",
     image: "kernel.svg.astro",
     description: "stupidly fast browser infra for your agents",
     link: "https://soydev.link/kernel",
+    categories: ["ai", "infrastructure"],
+    tier: "gold",
   },
   {
     name: "milkstraw",
     image: "milkstraw.svg.astro",
     description: "save up to 50% on your aws bill",
     link: "https://soydev.link/milkstraw",
+    categories: ["finance", "infrastructure"],
   },
   {
     name: "trigger.dev",
     image: "trigger.svg.astro",
     description: "fully managed ai agents and workflows",
     link: "https://soydev.link/trigger",
+    categories: ["ai", "developer-tools"],
+    slug: "trigger-dev",
   },
   {
     name: "magicpatterns",
     image: "magicpattern.svg.astro",
     description: "the ai design tool for teams that get product",
     link: "https://soydev.link/magicpatterns",
+    categories: ["ai", "design"],
   },
   {
     name: "sent.dm",
     image: "sentdm.svg.astro",
     description: "imagine if twillio was good...",
     link: "https://soydev.link/sentdm",
+    categories: ["communications"],
+    slug: "sent-dm",
   },
-] satisfies Sponsor[];
+];
+
+export const affiliates = affiliateSeeds.map((brand) =>
+  defineSponsor("affiliate", brand),
+);
+
+export const sponsors = sponsorSeeds.map((brand) =>
+  defineSponsor("sponsor", brand),
+);
+
+export const sponsorDirectory = [...sponsors, ...affiliates];
+
+export const usedSponsorCategories = sponsorCategoryOptions.filter(
+  ({ slug }) => {
+    return sponsorDirectory.some((brand) => brand.categories.includes(slug));
+  },
+);
+
+export const getSponsorBySlug = (slug: string) => {
+  return sponsorDirectory.find((brand) => brand.slug === slug);
+};
+
+const sponsorTierSlugOrder: Record<SponsorTier, string[]> = {
+  platinum: ["workos", "blacksmith", "browserbase"],
+  gold: ["kernel", "clerk", "greptile", "kilo", "depot", "coderabbit"],
+  silver: ["arcjet", "g2i", "posthog"],
+};
+
+const sortSponsorsBySlugOrder = (order: string[], list: SponsorEntry[]) => {
+  const rank = (slug: string) => {
+    const i = order.indexOf(slug);
+    return i === -1 ? order.length + 1 : i;
+  };
+  return [...list].sort((a, b) => rank(a.slug) - rank(b.slug));
+};
+
+export const getSponsorDirectorySections = (): SponsorDirectorySection[] => {
+  const tierSections: SponsorDirectorySection[] = sponsorTierOrder
+    .map((tier) => ({
+      id: tier,
+      heading: tier,
+      sponsors: sortSponsorsBySlugOrder(
+        sponsorTierSlugOrder[tier],
+        sponsors.filter((brand) => brand.tier === tier),
+      ),
+    }))
+    .filter((section) => section.sponsors.length > 0);
+
+  const directorySections: SponsorDirectorySection[] = [...tierSections];
+  const untieredSponsors = sponsors.filter((brand) => brand.tier === null);
+
+  if (untieredSponsors.length > 0) {
+    directorySections.push({
+      id: "past-sponsors",
+      heading: "past sponsors",
+      sponsors: untieredSponsors,
+    });
+  }
+
+  if (affiliates.length > 0) {
+    directorySections.push({
+      id: "affiliate-deals",
+      heading: "affiliate deals",
+      sponsors: affiliates,
+    });
+  }
+
+  return directorySections;
+};

--- a/src/lib/sponsors.ts
+++ b/src/lib/sponsors.ts
@@ -205,7 +205,7 @@ const sponsorSeeds: SponsorSeed[] = [
     name: "posthog",
     image: "posthog.svg.astro",
     description:
-      '"All in one suite of product tools" - also the only analytics provider i don\'t hate. open source too!',
+      'open source product analytics, feature flags, and llm observability',
     link: "https://soydev.link/posthog",
     categories: ["analytics", "developer-tools"],
     tier: "silver",
@@ -216,7 +216,7 @@ const sponsorSeeds: SponsorSeed[] = [
     description: "ai code review that doesn't suck.",
     link: "https://soydev.link/coderabbit",
     categories: ["ai", "developer-tools"],
-    tier: "gold",
+    tier: "platinum",
   },
   {
     name: "imagekit",
@@ -238,7 +238,7 @@ const sponsorSeeds: SponsorSeed[] = [
     name: "kilo",
     image: "kilo.svg.astro",
     description:
-      "the open source ai coding agent for vscode that codes, architects, debugs, and much more.",
+      "the open source code agent that works everywhere with every model",
     link: "https://soydev.link/kilo",
     categories: ["ai", "developer-tools"],
     tier: "gold",
@@ -315,7 +315,7 @@ const sponsorSeeds: SponsorSeed[] = [
     name: "graphite",
     image: "graphite.svg.astro",
     description:
-      "if github is slowing you down, graphite will speed you back up. better pr flows for fast moving teams (used by vercel, ramp, snowflake, brex and more)",
+      "github reimagined for people who hate github.",
     link: "https://soydev.link/graphite",
     categories: ["developer-tools", "productivity"],
   },
@@ -323,7 +323,7 @@ const sponsorSeeds: SponsorSeed[] = [
     name: "g2i",
     image: "g2i.svg.astro",
     description:
-      "stop hiring bad engineers. g2i will do real video interviews with hundreds of candidates to get you the best possible engineer in weeks.",
+      "hire great engineers in days instead of weeks.",
     link: "https://soydev.link/g2i",
     categories: ["hiring"],
     tier: "silver",
@@ -385,7 +385,7 @@ const sponsorSeeds: SponsorSeed[] = [
     name: "browserbase",
     image: "browserbase.svg.astro",
     description:
-      "web browser for your ai. prompt for parsing, dodge captchas, get data out of anything.",
+      "cloud browser infrastructure for ai agents",
     link: "https://soydev.link/browserbase",
     categories: ["ai", "infrastructure"],
     tier: "platinum",
@@ -650,14 +650,6 @@ const sponsorSeeds: SponsorSeed[] = [
     categories: ["deployment", "developer-tools"],
   },
   {
-    name: "kernel",
-    image: "kernel.svg.astro",
-    description: "stupidly fast browser infra for your agents",
-    link: "https://soydev.link/kernel",
-    categories: ["ai", "infrastructure"],
-    tier: "gold",
-  },
-  {
     name: "milkstraw",
     image: "milkstraw.svg.astro",
     description: "save up to 50% on your aws bill",
@@ -687,6 +679,14 @@ const sponsorSeeds: SponsorSeed[] = [
     categories: ["communications"],
     slug: "sent-dm",
   },
+  {
+    name: "kernel",
+    image: "kernel.svg.astro",
+    description: "stupidly fast browser infra for your agents",
+    link: "https://soydev.link/kernel",
+    categories: ["ai", "infrastructure"],
+    tier: "gold",
+  },
 ];
 
 export const affiliates = affiliateSeeds.map((brand) =>
@@ -710,8 +710,8 @@ export const getSponsorBySlug = (slug: string) => {
 };
 
 const sponsorTierSlugOrder: Record<SponsorTier, string[]> = {
-  platinum: ["workos", "blacksmith", "browserbase"],
-  gold: ["kernel", "clerk", "greptile", "kilo", "depot", "coderabbit"],
+  platinum: ["workos", "blacksmith", "browserbase", "coderabbit"],
+  gold: ["clerk", "greptile", "kilo", "depot", "kernel"],
   silver: ["arcjet", "g2i", "posthog"],
 };
 

--- a/src/lib/sponsors.ts
+++ b/src/lib/sponsors.ts
@@ -6,6 +6,7 @@ export const sponsorCategoryOptions = [
   { slug: "ai", label: "ai" },
   { slug: "analytics", label: "analytics" },
   { slug: "auth", label: "auth" },
+  { slug: "ci", label: "ci" },
   { slug: "communications", label: "communications" },
   { slug: "data", label: "data" },
   { slug: "deployment", label: "deployment" },
@@ -232,7 +233,7 @@ const sponsorSeeds: SponsorSeed[] = [
     image: "blacksmith.svg.astro",
     description: "github actions but they're 2x faster and way cheaper.",
     link: "https://soydev.link/blacksmith",
-    categories: ["developer-tools", "infrastructure"],
+    categories: ["ci", "developer-tools", "infrastructure"],
     tier: "platinum",
   },
   {
@@ -341,7 +342,7 @@ const sponsorSeeds: SponsorSeed[] = [
     image: "depot.svg.astro",
     description: "40x faster docker builds used by posthog and so many more.",
     link: "https://soydev.link/depot",
-    categories: ["developer-tools", "infrastructure"],
+    categories: ["ci", "developer-tools", "infrastructure"],
     tier: "gold",
   },
   {
@@ -647,7 +648,7 @@ const sponsorSeeds: SponsorSeed[] = [
     image: "rwx.svg.astro",
     description: "the best modern ci/cd for teams that actually ship",
     link: "https://soydev.link/rwx",
-    categories: ["deployment", "developer-tools"],
+    categories: ["ci", "deployment", "developer-tools"],
     tier: "new",
   },
   {

--- a/src/lib/sponsors.ts
+++ b/src/lib/sponsors.ts
@@ -671,11 +671,6 @@ export const usedSponsorCategories = sponsorCategoryOptions.filter(
   },
 );
 
-export const getSponsorBySlug = (slug: string) => {
-  return sponsorDirectory.find((brand) => brand.slug === slug);
-};
-
-
 const sponsorTierSlugOrder: Record<SponsorTier, string[]> = {
   platinum: ["workos", "blacksmith", "browserbase", "coderabbit"],
   gold: ["clerk", "greptile", "kilo", "depot"],

--- a/src/lib/sponsors.ts
+++ b/src/lib/sponsors.ts
@@ -350,6 +350,7 @@ const sponsorSeeds: SponsorSeed[] = [
     description: "the best way to setup, run, and scale your ai agents.",
     link: "https://soydev.link/agentuity",
     categories: ["ai", "infrastructure"],
+    tier: "silver",
   },
   {
     name: "chef by convex",
@@ -513,7 +514,7 @@ const sponsorSeeds: SponsorSeed[] = [
       "ai code assistant built for large codebases. works with vs code, jetbrains, and neovim.",
     link: "https://soydev.link/augmentcode",
     categories: ["ai", "developer-tools"],
-    tier: "new",
+    tier: "silver",
   },
   {
     name: "vercel",
@@ -618,14 +619,6 @@ const sponsorSeeds: SponsorSeed[] = [
     categories: ["developer-tools", "security"],
   },
   {
-    name: "jfrog fly",
-    image: "jfrog.svg.astro",
-    description: "artifact management that's built for your ai agents",
-    link: "https://soydev.link/jfrogfly",
-    categories: ["developer-tools", "infrastructure"],
-    slug: "jfrog-fly",
-  },
-  {
     name: "wispr flow",
     image: "wispr.svg.astro",
     description: "the voice to text product that i can't live without",
@@ -723,8 +716,8 @@ export const getSponsorBySlug = (slug: string) => {
 const sponsorTierSlugOrder: Record<SponsorTier, string[]> = {
   platinum: ["workos", "blacksmith", "browserbase", "coderabbit"],
   gold: ["clerk", "greptile", "kilo", "depot"],
-  silver: ["infinite-red", "arcjet", "g2i", "posthog"],
-  new: ["embrace", "rork", "daytona", "milkstraw", "sent-dm", "trigger-dev", "magicpatterns", "rwx", "wispr-flow", "dnsimple", "augment-code"],
+  silver: ["infinite-red", "arcjet", "g2i", "posthog", "augment-code", "agentuity"],
+  new: ["embrace", "rork", "daytona", "milkstraw", "sent-dm", "trigger-dev", "magicpatterns", "rwx", "wispr-flow", "dnsimple"],
 };
 
 const sortSponsorsBySlugOrder = (order: string[], list: SponsorEntry[]) => {

--- a/src/lib/sponsors.ts
+++ b/src/lib/sponsors.ts
@@ -622,7 +622,7 @@ const sponsorSeeds: SponsorSeed[] = [
     name: "wispr flow",
     image: "wispr.svg.astro",
     description: "the voice to text product that i can't live without",
-    link: "https://soydev.link/wispr",
+    link: "https://soydev.link/wisprflow",
     categories: ["productivity"],
     slug: "wispr-flow",
     tier: "new",

--- a/src/lib/sponsors.ts
+++ b/src/lib/sponsors.ts
@@ -685,7 +685,6 @@ const sponsorSeeds: SponsorSeed[] = [
     description: "stupidly fast browser infra for your agents",
     link: "https://soydev.link/kernel",
     categories: ["ai", "infrastructure"],
-    tier: "gold",
   },
 ];
 
@@ -711,7 +710,7 @@ export const getSponsorBySlug = (slug: string) => {
 
 const sponsorTierSlugOrder: Record<SponsorTier, string[]> = {
   platinum: ["workos", "blacksmith", "browserbase", "coderabbit"],
-  gold: ["clerk", "greptile", "kilo", "depot", "kernel"],
+  gold: ["clerk", "greptile", "kilo", "depot"],
   silver: ["arcjet", "g2i", "posthog"],
 };
 

--- a/src/lib/sponsors.ts
+++ b/src/lib/sponsors.ts
@@ -378,7 +378,7 @@ const sponsorSeeds: SponsorSeed[] = [
   {
     name: "clerk",
     image: "clerk.svg.astro",
-    description: "the only auth solution i don't hate using.",
+    description: "auth that your devs and agents will love",
     link: "https://soydev.link/clerk",
     categories: ["auth", "security"],
     tier: "gold",

--- a/src/lib/sponsors.ts
+++ b/src/lib/sponsors.ts
@@ -1,4 +1,4 @@
-export const sponsorTierOrder = ["platinum", "gold", "silver"] as const;
+export const sponsorTierOrder = ["platinum", "gold", "silver", "new"] as const;
 
 export type SponsorTier = (typeof sponsorTierOrder)[number];
 
@@ -192,6 +192,7 @@ const sponsorSeeds: SponsorSeed[] = [
     description: "the first people i call for react native help.",
     link: "https://soydev.link/infinitered",
     categories: ["developer-tools", "frontend"],
+    tier: "silver",
   },
   {
     name: "sevalla",
@@ -512,6 +513,7 @@ const sponsorSeeds: SponsorSeed[] = [
       "ai code assistant built for large codebases. works with vs code, jetbrains, and neovim.",
     link: "https://soydev.link/augmentcode",
     categories: ["ai", "developer-tools"],
+    tier: "new",
   },
   {
     name: "vercel",
@@ -562,6 +564,7 @@ const sponsorSeeds: SponsorSeed[] = [
     description: "web and mobile observability that's actually amazing",
     link: "https://soydev.link/embrace",
     categories: ["monitoring"],
+    tier: "new",
   },
   {
     name: "exa",
@@ -576,6 +579,7 @@ const sponsorSeeds: SponsorSeed[] = [
     description: "the place where you let agents run their code",
     link: "https://soydev.link/daytona",
     categories: ["ai", "infrastructure"],
+    tier: "new",
   },
   {
     name: "rork",
@@ -583,6 +587,7 @@ const sponsorSeeds: SponsorSeed[] = [
     description: "the vibe coding platform that actually gets react native",
     link: "https://soydev.link/rork",
     categories: ["ai", "frontend"],
+    tier: "new",
   },
   {
     name: "modal",
@@ -627,6 +632,7 @@ const sponsorSeeds: SponsorSeed[] = [
     link: "https://soydev.link/wispr",
     categories: ["productivity"],
     slug: "wispr-flow",
+    tier: "new",
   },
   {
     name: "dnsimple",
@@ -634,6 +640,7 @@ const sponsorSeeds: SponsorSeed[] = [
     description: "the best way to manage your domains and dns",
     link: "https://soydev.link/dnsimple",
     categories: ["deployment", "infrastructure"],
+    tier: "new",
   },
   {
     name: "railway",
@@ -648,6 +655,7 @@ const sponsorSeeds: SponsorSeed[] = [
     description: "the best modern ci/cd for teams that actually ship",
     link: "https://soydev.link/rwx",
     categories: ["deployment", "developer-tools"],
+    tier: "new",
   },
   {
     name: "milkstraw",
@@ -655,6 +663,7 @@ const sponsorSeeds: SponsorSeed[] = [
     description: "save up to 50% on your aws bill",
     link: "https://soydev.link/milkstraw",
     categories: ["finance", "infrastructure"],
+    tier: "new",
   },
   {
     name: "trigger.dev",
@@ -663,6 +672,7 @@ const sponsorSeeds: SponsorSeed[] = [
     link: "https://soydev.link/trigger",
     categories: ["ai", "developer-tools"],
     slug: "trigger-dev",
+    tier: "new",
   },
   {
     name: "magicpatterns",
@@ -670,6 +680,7 @@ const sponsorSeeds: SponsorSeed[] = [
     description: "the ai design tool for teams that get product",
     link: "https://soydev.link/magicpatterns",
     categories: ["ai", "design"],
+    tier: "new",
   },
   {
     name: "sent.dm",
@@ -678,6 +689,7 @@ const sponsorSeeds: SponsorSeed[] = [
     link: "https://soydev.link/sentdm",
     categories: ["communications"],
     slug: "sent-dm",
+    tier: "new",
   },
   {
     name: "kernel",
@@ -711,7 +723,8 @@ export const getSponsorBySlug = (slug: string) => {
 const sponsorTierSlugOrder: Record<SponsorTier, string[]> = {
   platinum: ["workos", "blacksmith", "browserbase", "coderabbit"],
   gold: ["clerk", "greptile", "kilo", "depot"],
-  silver: ["arcjet", "g2i", "posthog"],
+  silver: ["infinite-red", "arcjet", "g2i", "posthog"],
+  new: ["embrace", "rork", "daytona", "milkstraw", "sent-dm", "trigger-dev", "magicpatterns", "rwx", "wispr-flow", "dnsimple", "augment-code"],
 };
 
 const sortSponsorsBySlugOrder = (order: string[], list: SponsorEntry[]) => {
@@ -722,11 +735,18 @@ const sortSponsorsBySlugOrder = (order: string[], list: SponsorEntry[]) => {
   return [...list].sort((a, b) => rank(a.slug) - rank(b.slug));
 };
 
+const tierHeadings: Record<SponsorTier, string> = {
+  platinum: "platinum",
+  gold: "gold",
+  silver: "silver",
+  new: "new sponsors",
+};
+
 export const getSponsorDirectorySections = (): SponsorDirectorySection[] => {
   const tierSections: SponsorDirectorySection[] = sponsorTierOrder
     .map((tier) => ({
       id: tier,
-      heading: tier,
+      heading: tierHeadings[tier],
       sponsors: sortSponsorsBySlugOrder(
         sponsorTierSlugOrder[tier],
         sponsors.filter((brand) => brand.tier === tier),

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,10 +5,23 @@ const siteTitle = "theo";
 const description =
   "theo (aka t3, t3dotgg) is a youtuber/ceo/dev. built t3 chat, ping.gg, t3 stack and more.";
 
+const socialLinks = [
+  { href: "https://github.com/t3dotgg", label: "gh" },
+  { href: "https://twitter.com/theo", label: "x" },
+  { href: "https://youtube.com/@t3dotgg", label: "yt" },
+  { href: "https://twitch.tv/theo", label: "twitch" },
+  { href: "https://discord.gg/xHdCpcPHRE", label: "discord" },
+];
+
 const links = [
   {
     href: "https://t3.chat",
     label: "t3.chat",
+    external: true,
+  },
+  {
+    href: "https://t3.codes",
+    label: "t3.code",
     external: true,
   },
   {
@@ -100,6 +113,25 @@ const links = [
           ))
         }
       </nav>
+
+      <!-- Footer -->
+      <footer
+        class="mt-16 flex items-center gap-x-5 border-t border-white/5 pt-6 text-sm tracking-wider opacity-0 animate-fade-in-up"
+        style={`animation-delay: ${(links.length + 1) * 0.05}s;`}
+      >
+        {
+          socialLinks.map((link) => (
+            <a
+              href={link.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-muted transition-colors duration-200 hover:text-text"
+            >
+              {link.label}
+            </a>
+          ))
+        }
+      </footer>
     </div>
   </div>
 </BaseLayout>

--- a/src/pages/sponsors.astro
+++ b/src/pages/sponsors.astro
@@ -56,8 +56,7 @@ const sponsorSections = getSponsorDirectorySections();
 
       <h1 class="text-text text-2xl tracking-tight">sponsors</h1>
       <p class="text-muted mt-2 max-w-2xl text-sm leading-7">
-        brands that have run ads on my content, organized by tier and easy to
-        browse by search or category.
+        brands that have run ads on my content
       </p>
       <p class="text-subtle mt-4 text-sm">
         want to sponsor?

--- a/src/pages/sponsors.astro
+++ b/src/pages/sponsors.astro
@@ -2,44 +2,179 @@
 import "../style/global.css";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import SponsorGridSection from "../components/SponsorGridSection.astro";
-import { affiliates, sponsors } from "../lib/sponsors";
+import {
+  getSponsorDirectorySections,
+  usedSponsorCategories,
+} from "../lib/sponsors";
 
 const siteTitle = "sponsors";
 const description = "all of the brands running ads on my youtube channel";
+
+const sponsorSections = getSponsorDirectorySections();
 ---
 
 <BaseLayout title={siteTitle} description={description}>
-  <div class="mx-auto w-full max-w-5xl px-6 py-16">
+  <div
+    data-sponsor-directory
+    class="relative mx-auto w-full max-w-6xl px-6 py-16"
+  >
     <header
-      class="animate-fade-in-up mb-16 opacity-0"
+      class="animate-fade-in-up relative mb-10 pr-12 opacity-0 sm:pr-14"
       style="animation-delay: 0s;"
     >
+      <button
+        type="button"
+        data-sponsor-filters-toggle
+        aria-expanded="false"
+        aria-controls="sponsor-filters-expandable"
+        aria-label="Search and filter sponsors"
+        class="group text-subtle hover:text-text data-[open=true]:text-accent absolute top-0 right-0 flex size-11 items-center justify-center rounded-xl border border-white/10 transition-colors duration-200 hover:border-white/20 data-[open=true]:border-cyan-400/30"
+        data-open="false"
+      >
+        <span class="relative inline-flex">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="size-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="1.75"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 01-.659 1.591l-5.432 5.432a2.25 2.25 0 00-.659 1.591v2.927a2.25 2.25 0 01-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 00-.659-1.591L3.659 7.409A2.25 2.25 0 013 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0112 3z"
+            ></path>
+          </svg>
+          <span
+            data-sponsor-filters-active-dot
+            class="bg-accent ring-void absolute -top-0.5 -right-0.5 hidden size-2 rounded-full ring-2"
+            aria-hidden="true"></span>
+        </span>
+      </button>
+
       <h1 class="text-text text-2xl tracking-tight">sponsors</h1>
-      <p class="text-muted mt-2 text-sm">
-        brands that have run ads on my content
+      <p class="text-muted mt-2 max-w-2xl text-sm leading-7">
+        brands that have run ads on my content, organized by tier and easy to
+        browse by search or category.
       </p>
       <p class="text-subtle mt-4 text-sm">
         want to sponsor?
         <a
           href="/sponsor-me"
-          class="text-accent hover:text-text transition-colors"
+          class="text-accent hover:text-text transition-colors duration-200"
         >
           learn more
         </a>
       </p>
     </header>
 
-    <div class="animate-fade-in-up opacity-0" style="animation-delay: 0.1s;">
-      <SponsorGridSection
-        heading="affiliates"
-        sponsors={affiliates}
-        class="mb-16"
-      />
+    <div
+      id="sponsor-filters-expandable"
+      data-sponsor-filters-panel
+      hidden
+      class="bg-surface/50 animate-fade-in-up mb-10 rounded-2xl border border-white/5 p-5 opacity-0 md:p-6"
+      style="animation-delay: 0.05s;"
+    >
+      <div class="max-w-2xl">
+        <h2 class="text-muted text-sm tracking-wider uppercase">
+          search and filter
+        </h2>
+        <p class="text-subtle mt-2 text-sm leading-7">
+          search by name or description, then narrow things down by category.
+        </p>
+      </div>
+
+      <div class="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
+        <label class="flex flex-col gap-2">
+          <span class="text-muted text-[11px] tracking-wider uppercase">
+            search
+          </span>
+          <input
+            type="search"
+            name="q"
+            data-sponsor-search
+            placeholder="search sponsors"
+            class="bg-void text-text placeholder:text-muted rounded-lg border border-white/10 px-4 py-3 text-sm transition-colors outline-none focus:border-cyan-400/40"
+          />
+        </label>
+
+        <div class="flex flex-col gap-3">
+          <p class="text-muted text-[11px] tracking-wider uppercase">
+            categories
+          </p>
+          <div class="flex flex-wrap gap-2">
+            {
+              usedSponsorCategories.map(({ slug, label }) => (
+                <button
+                  type="button"
+                  value={slug}
+                  data-category-filter
+                  data-active="false"
+                  aria-pressed="false"
+                  class="text-subtle hover:text-text data-[active=true]:text-accent rounded-full border border-white/10 px-3 py-1.5 text-[11px] tracking-wider uppercase transition-colors duration-200 hover:border-white/20 data-[active=true]:border-cyan-400/20 data-[active=true]:bg-cyan-400/10"
+                >
+                  {label}
+                </button>
+              ))
+            }
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-6 flex justify-end border-t border-white/5 pt-5">
+        <button
+          type="button"
+          data-clear-filters
+          class="text-subtle hover:text-text inline-flex rounded-lg border border-white/10 px-4 py-2 text-[11px] tracking-wider uppercase transition-colors duration-200 hover:border-white/20"
+        >
+          clear filters
+        </button>
+      </div>
     </div>
 
-    <div class="animate-fade-in-up opacity-0" style="animation-delay: 0.15s;">
-      <SponsorGridSection heading="video sponsors" sponsors={sponsors} />
+    <div class="space-y-14">
+      {
+        sponsorSections.map((section, index) => (
+          <div
+            class="animate-fade-in-up opacity-0"
+            style={`animation-delay: ${0.1 + index * 0.05}s;`}
+          >
+            <SponsorGridSection
+              id={section.id}
+              heading={section.heading}
+              sponsors={section.sponsors}
+              variant={
+                section.id === "platinum"
+                  ? "platinum"
+                  : section.id === "gold"
+                    ? "gold"
+                    : section.id === "silver"
+                      ? "silver"
+                      : "default"
+              }
+            />
+          </div>
+        ))
+      }
     </div>
+
+    <section
+      class="animate-fade-in-up mt-8 opacity-0"
+      style="animation-delay: 0.15s;"
+      data-no-results
+      hidden
+    >
+      <div
+        class="bg-surface/50 rounded-2xl border border-white/5 px-6 py-10 text-center"
+      >
+        <h2 class="text-muted text-sm tracking-wider uppercase">no matches</h2>
+        <p class="text-subtle mt-3 text-sm leading-7">
+          try a different search or clear some filters.
+        </p>
+      </div>
+    </section>
 
     <footer
       class="text-muted animate-fade-in-up mt-24 text-center text-sm opacity-0"
@@ -48,10 +183,208 @@ const description = "all of the brands running ads on my youtube channel";
       interested in sponsoring?
       <a
         href="/sponsor-me"
-        class="text-accent hover:text-text transition-colors"
+        class="text-accent hover:text-text transition-colors duration-200"
       >
         get in touch
       </a>
     </footer>
   </div>
 </BaseLayout>
+
+<script>
+  const initSponsorDirectory = () => {
+    const root = document.querySelector("[data-sponsor-directory]");
+
+    if (!(root instanceof HTMLElement) || root.dataset.initialized === "true") {
+      return;
+    }
+
+    root.dataset.initialized = "true";
+
+    const searchInput = root.querySelector("[data-sponsor-search]");
+    const noResults = root.querySelector("[data-no-results]");
+    const clearFiltersButton = root.querySelector("[data-clear-filters]");
+    const filtersToggle = root.querySelector("[data-sponsor-filters-toggle]");
+    const filtersPanel = root.querySelector("[data-sponsor-filters-panel]");
+    const activeDot = root.querySelector("[data-sponsor-filters-active-dot]");
+    const sectionElements = Array.from(
+      root.querySelectorAll("[data-sponsor-section]"),
+    );
+    const categoryButtons = Array.from(
+      root.querySelectorAll("[data-category-filter]"),
+    );
+
+    if (!(searchInput instanceof HTMLInputElement)) {
+      return;
+    }
+
+    const setFiltersOpen = (open: boolean) => {
+      if (!(filtersPanel instanceof HTMLElement)) {
+        return;
+      }
+      if (!(filtersToggle instanceof HTMLButtonElement)) {
+        return;
+      }
+      filtersPanel.hidden = !open;
+      filtersToggle.setAttribute("aria-expanded", String(open));
+      filtersToggle.dataset.open = String(open);
+    };
+
+    if (filtersToggle instanceof HTMLButtonElement) {
+      filtersToggle.addEventListener("click", () => {
+        const open = filtersPanel instanceof HTMLElement && filtersPanel.hidden;
+        setFiltersOpen(open);
+      });
+    }
+
+    const getSelectedCategories = () => {
+      return categoryButtons.flatMap((button) => {
+        if (!(button instanceof HTMLButtonElement)) {
+          return [];
+        }
+
+        return button.dataset.active === "true" ? [button.value] : [];
+      });
+    };
+
+    const syncCategoryButtons = (selectedCategories: string[]) => {
+      categoryButtons.forEach((button) => {
+        if (!(button instanceof HTMLButtonElement)) {
+          return;
+        }
+
+        const isActive = selectedCategories.includes(button.value);
+        button.dataset.active = String(isActive);
+        button.setAttribute("aria-pressed", String(isActive));
+      });
+    };
+
+    const syncUrl = (query: string, selectedCategories: string[]) => {
+      const nextUrl = new URL(window.location.href);
+
+      if (query) {
+        nextUrl.searchParams.set("q", query);
+      } else {
+        nextUrl.searchParams.delete("q");
+      }
+
+      if (selectedCategories.length > 0) {
+        nextUrl.searchParams.set("categories", selectedCategories.join(","));
+      } else {
+        nextUrl.searchParams.delete("categories");
+      }
+
+      const nextHref = `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`;
+      window.history.replaceState({}, "", nextHref);
+    };
+
+    const applyFilters = ({ updateUrl } = { updateUrl: true }) => {
+      const query = searchInput.value.trim().toLowerCase();
+      const selectedCategories = getSelectedCategories();
+      let visibleCardCount = 0;
+
+      sectionElements.forEach((section) => {
+        if (!(section instanceof HTMLElement)) {
+          return;
+        }
+
+        const cards = Array.from(
+          section.querySelectorAll("[data-sponsor-card]"),
+        );
+        let visibleSectionCount = 0;
+
+        cards.forEach((card) => {
+          if (!(card instanceof HTMLElement)) {
+            return;
+          }
+
+          const searchTarget = card.dataset.search ?? "";
+          const cardCategories = (card.dataset.categories ?? "")
+            .split(",")
+            .filter(Boolean);
+
+          const matchesQuery =
+            query.length === 0 || searchTarget.includes(query);
+          const matchesCategory =
+            selectedCategories.length === 0 ||
+            selectedCategories.some((category) =>
+              cardCategories.includes(category),
+            );
+          const isVisible = matchesQuery && matchesCategory;
+
+          card.hidden = !isVisible;
+
+          if (isVisible) {
+            visibleCardCount += 1;
+            visibleSectionCount += 1;
+          }
+        });
+
+        section.hidden = visibleSectionCount === 0;
+      });
+
+      if (noResults instanceof HTMLElement) {
+        noResults.hidden = visibleCardCount !== 0;
+      }
+
+      if (activeDot instanceof HTMLElement) {
+        const activeCount =
+          (query.length > 0 ? 1 : 0) + selectedCategories.length;
+        activeDot.classList.toggle("hidden", activeCount === 0);
+      }
+
+      if (updateUrl) {
+        syncUrl(query, selectedCategories);
+      }
+    };
+
+    const syncControlsFromUrl = () => {
+      const searchParams = new URLSearchParams(window.location.search);
+      const query = searchParams.get("q") ?? "";
+      const selectedCategories = (searchParams.get("categories") ?? "")
+        .split(",")
+        .filter(Boolean);
+
+      searchInput.value = query;
+      syncCategoryButtons(selectedCategories);
+    };
+
+    categoryButtons.forEach((button) => {
+      if (!(button instanceof HTMLButtonElement)) {
+        return;
+      }
+
+      button.addEventListener("click", () => {
+        const isActive = button.dataset.active === "true";
+        button.dataset.active = String(!isActive);
+        button.setAttribute("aria-pressed", String(!isActive));
+        applyFilters();
+      });
+    });
+
+    searchInput.addEventListener("input", () => {
+      applyFilters();
+    });
+
+    if (clearFiltersButton instanceof HTMLButtonElement) {
+      clearFiltersButton.addEventListener("click", () => {
+        searchInput.value = "";
+        syncCategoryButtons([]);
+        applyFilters();
+      });
+    }
+
+    syncControlsFromUrl();
+    const urlParams = new URLSearchParams(window.location.search);
+    const hasUrlFilters =
+      (urlParams.get("q") ?? "").trim().length > 0 ||
+      (urlParams.get("categories") ?? "").length > 0;
+    if (hasUrlFilters) {
+      setFiltersOpen(true);
+    }
+    applyFilters({ updateUrl: false });
+  };
+
+  initSponsorDirectory();
+  document.addEventListener("astro:page-load", initSponsorDirectory);
+</script>

--- a/src/pages/sponsors.astro
+++ b/src/pages/sponsors.astro
@@ -151,7 +151,9 @@ const sponsorSections = getSponsorDirectorySections();
                     ? "gold"
                     : section.id === "silver"
                       ? "silver"
-                      : "default"
+                      : section.id === "new"
+                        ? "new"
+                        : "default"
               }
             />
           </div>

--- a/src/pages/sponsors/[slug].astro
+++ b/src/pages/sponsors/[slug].astro
@@ -1,0 +1,154 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import SponsorLogo from "../../components/SponsorLogo.astro";
+import {
+  formatSponsorCategory,
+  formatSponsorTier,
+  sponsorDirectory,
+  type SponsorEntry,
+} from "../../lib/sponsors";
+
+export const getStaticPaths = () => {
+  return sponsorDirectory.map((sponsor) => ({
+    params: {
+      slug: sponsor.slug,
+    },
+    props: {
+      sponsor,
+    },
+  }));
+};
+
+interface Props {
+  sponsor: SponsorEntry;
+}
+
+const { sponsor } = Astro.props;
+
+const categoryLabels = sponsor.categories.map(formatSponsorCategory);
+const backToLink = {
+  text: "back to sponsors",
+  href: "/sponsors",
+};
+---
+
+<BaseLayout
+  title={sponsor.page.seoTitle}
+  description={sponsor.page.seoDescription}
+  {backToLink}
+>
+  <div class="mx-auto w-full max-w-5xl px-6 py-16">
+    <header
+      class="bg-surface/50 animate-fade-in-up rounded-2xl border border-white/5 p-6 opacity-0 md:p-8"
+      style="animation-delay: 0s;"
+    >
+      <div class="flex flex-col gap-6 md:flex-row md:items-start">
+        <SponsorLogo
+          image={sponsor.image}
+          name={sponsor.name}
+          class="size-16 md:size-20"
+        />
+
+        <div class="min-w-0 flex-1">
+          <div class="flex flex-wrap gap-2">
+            {
+              sponsor.tier && (
+                <span class="text-accent rounded-full border border-cyan-400/20 bg-cyan-400/10 px-2 py-1 text-[10px] tracking-wider uppercase">
+                  {formatSponsorTier(sponsor.tier)}
+                </span>
+              )
+            }
+            <span
+              class="text-subtle rounded-full border border-white/10 px-2 py-1 text-[10px] tracking-wider uppercase"
+            >
+              {
+                sponsor.kind === "affiliate"
+                  ? "affiliate deal"
+                  : "video sponsor"
+              }
+            </span>
+            {
+              categoryLabels.map((label) => (
+                <span class="text-subtle rounded-full border border-white/10 px-2 py-1 text-[10px] tracking-wider uppercase">
+                  {label}
+                </span>
+              ))
+            }
+          </div>
+
+          <h1 class="text-text mt-4 text-2xl tracking-tight md:text-3xl">
+            {sponsor.name}
+          </h1>
+          <p class="text-subtle mt-3 max-w-3xl text-sm leading-7">
+            {sponsor.page.intro}
+          </p>
+
+          <div class="mt-6 flex flex-wrap gap-3">
+            <a
+              href={sponsor.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-accent hover:text-text inline-flex rounded-lg border border-cyan-400/20 bg-cyan-400/10 px-4 py-2 text-xs tracking-wider uppercase transition-colors duration-200 hover:border-cyan-400/40"
+            >
+              {sponsor.page.primaryCtaLabel}
+            </a>
+            <a
+              href="/sponsors"
+              class="text-subtle hover:text-text inline-flex rounded-lg border border-white/10 px-4 py-2 text-xs tracking-wider uppercase transition-colors duration-200 hover:border-white/20"
+            >
+              browse all sponsors
+            </a>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <section
+      class="animate-fade-in-up mt-6 grid gap-4 opacity-0 md:grid-cols-3"
+      style="animation-delay: 0.05s;"
+    >
+      <div class="bg-surface/50 rounded-2xl border border-white/5 p-5">
+        <p class="text-muted text-[10px] tracking-wider uppercase">
+          relationship
+        </p>
+        <p class="text-text mt-2 text-sm">
+          {sponsor.kind === "affiliate" ? "affiliate deal" : "video sponsor"}
+        </p>
+      </div>
+      <div class="bg-surface/50 rounded-2xl border border-white/5 p-5">
+        <p class="text-muted text-[10px] tracking-wider uppercase">tier</p>
+        <p class="text-text mt-2 text-sm">
+          {
+            sponsor.kind === "affiliate"
+              ? "—"
+              : sponsor.tier
+                ? formatSponsorTier(sponsor.tier)
+                : "past sponsor"
+          }
+        </p>
+      </div>
+      <div class="bg-surface/50 rounded-2xl border border-white/5 p-5">
+        <p class="text-muted text-[10px] tracking-wider uppercase">
+          categories
+        </p>
+        <p class="text-text mt-2 text-sm">{categoryLabels.join(", ")}</p>
+      </div>
+    </section>
+
+    <section
+      class="animate-fade-in-up mt-6 grid gap-4 opacity-0 lg:grid-cols-3"
+      style="animation-delay: 0.1s;"
+    >
+      {
+        sponsor.page.bodySections.map((section) => (
+          <section class="bg-surface/50 rounded-2xl border border-white/5 p-6">
+            <h2 class="text-muted text-sm tracking-wider uppercase">
+              {section.heading}
+            </h2>
+            <p class="text-subtle mt-3 text-sm leading-7">{section.content}</p>
+          </section>
+        ))
+      }
+    </section>
+  </div>
+</BaseLayout>

--- a/src/pages/sponsors/[slug].astro
+++ b/src/pages/sponsors/[slug].astro
@@ -100,53 +100,5 @@ const backToLink = {
         </div>
       </div>
     </header>
-
-    <section
-      class="animate-fade-in-up mt-6 grid gap-4 opacity-0 md:grid-cols-3"
-      style="animation-delay: 0.05s;"
-    >
-      <div class="bg-surface/50 rounded-2xl border border-white/5 p-5">
-        <p class="text-muted text-[10px] tracking-wider uppercase">
-          relationship
-        </p>
-        <p class="text-text mt-2 text-sm">
-          {sponsor.kind === "affiliate" ? "affiliate deal" : "sponsor"}
-        </p>
-      </div>
-      <div class="bg-surface/50 rounded-2xl border border-white/5 p-5">
-        <p class="text-muted text-[10px] tracking-wider uppercase">tier</p>
-        <p class="text-text mt-2 text-sm">
-          {
-            sponsor.kind === "affiliate"
-              ? "—"
-              : sponsor.tier
-                ? formatSponsorTier(sponsor.tier)
-                : "past sponsor"
-          }
-        </p>
-      </div>
-      <div class="bg-surface/50 rounded-2xl border border-white/5 p-5">
-        <p class="text-muted text-[10px] tracking-wider uppercase">
-          categories
-        </p>
-        <p class="text-text mt-2 text-sm">{categoryLabels.join(", ")}</p>
-      </div>
-    </section>
-
-    <section
-      class="animate-fade-in-up mt-6 grid gap-4 opacity-0 lg:grid-cols-3"
-      style="animation-delay: 0.1s;"
-    >
-      {
-        sponsor.page.bodySections.map((section) => (
-          <section class="bg-surface/50 rounded-2xl border border-white/5 p-6">
-            <h2 class="text-muted text-sm tracking-wider uppercase">
-              {section.heading}
-            </h2>
-            <p class="text-subtle mt-3 text-sm leading-7">{section.content}</p>
-          </section>
-        ))
-      }
-    </section>
   </div>
 </BaseLayout>

--- a/src/pages/sponsors/[slug].astro
+++ b/src/pages/sponsors/[slug].astro
@@ -58,15 +58,13 @@ const backToLink = {
                 </span>
               )
             }
-            <span
-              class="text-subtle rounded-full border border-white/10 px-2 py-1 text-[10px] tracking-wider uppercase"
-            >
-              {
-                sponsor.kind === "affiliate"
-                  ? "affiliate deal"
-                  : "video sponsor"
-              }
-            </span>
+            {
+              sponsor.kind === "affiliate" && (
+                <span class="text-subtle rounded-full border border-white/10 px-2 py-1 text-[10px] tracking-wider uppercase">
+                  affiliate deal
+                </span>
+              )
+            }
             {
               categoryLabels.map((label) => (
                 <span class="text-subtle rounded-full border border-white/10 px-2 py-1 text-[10px] tracking-wider uppercase">
@@ -112,7 +110,7 @@ const backToLink = {
           relationship
         </p>
         <p class="text-text mt-2 text-sm">
-          {sponsor.kind === "affiliate" ? "affiliate deal" : "video sponsor"}
+          {sponsor.kind === "affiliate" ? "affiliate deal" : "sponsor"}
         </p>
       </div>
       <div class="bg-surface/50 rounded-2xl border border-white/5 p-5">

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -28,6 +28,12 @@
   font-display: swap;
 }
 
+@property --border-angle {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+
 @theme {
   /* dark-only color palette */
   --color-void: #050505;
@@ -46,6 +52,9 @@
   --color-white: var(--color-text);
   --color-theo-purple: #a78bfa;
   --color-theo-blue: var(--color-accent);
+
+  --color-gold: #d4a853;
+  --color-silver: #94a3b8;
 
   /* typography */
   --font-mono: "Geist Mono", ui-monospace, monospace;
@@ -85,6 +94,12 @@
     }
   }
 
+  @keyframes rotate-border {
+    to {
+      --border-angle: 360deg;
+    }
+  }
+
   /* stagger delays */
   --animate-delay-1: 0.05s;
   --animate-delay-2: 0.1s;
@@ -98,6 +113,32 @@
 /* custom `bg-texture` image utility */
 @utility bg-texture {
   @apply bg-[url(/images/bg-texture.png)] bg-fixed bg-center bg-repeat dark:bg-[url(/images/bg-texture_dark.png)];
+}
+
+.sponsor-card-platinum {
+  border: 1.5px solid transparent;
+  background:
+    linear-gradient(135deg, rgba(34, 211, 238, 0.06), #0a0a0a 40%, #080808)
+      padding-box,
+    conic-gradient(
+        from var(--border-angle),
+        rgba(34, 211, 238, 0.8),
+        rgba(167, 139, 250, 0.3),
+        rgba(34, 211, 238, 0.08),
+        rgba(167, 139, 250, 0.3),
+        rgba(34, 211, 238, 0.8)
+      )
+      border-box;
+  animation: rotate-border 4s linear infinite;
+  box-shadow: 0 0 60px -15px rgba(34, 211, 238, 0.25);
+  transition:
+    box-shadow 0.3s ease,
+    transform 0.3s ease;
+}
+
+.sponsor-card-platinum:hover {
+  box-shadow: 0 0 80px -10px rgba(34, 211, 238, 0.4);
+  transform: translateY(-2px);
 }
 
 /* custom view transition */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sponsor directory with search and category filtering functionality
  * Individual sponsor detail pages with tier information and call-to-action links
  * Sponsor display cards with tier-based visual variants (platinum, gold, silver, new)

* **Style**
  * Animated border effects for featured platinum sponsors
  * Expanded color palette with tier-specific color tokens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Overhaul sponsors page with filtering, per-sponsor detail pages, and homepage footer
> - Rewrites [sponsors.astro](https://github.com/T3-Content/t3.gg/pull/52/files#diff-9e8561c72ca9d2705f78b0c0e23cd32be3601087bb4adfcb20fdf8a087f2220c) with client-side search and category filtering, URL state sync, tiered section rendering via `getSponsorDirectorySections`, and a no-results fallback
> - Adds per-sponsor detail pages at `/sponsors/:slug` via [src/pages/sponsors/[slug].astro](https://github.com/T3-Content/t3.gg/pull/52/files#diff-d2334ec943c4bf10da6bf00801fa14afb7bebf5b375a1435119b29cd8e3ad757) with logo, tier/affiliate badges, category chips, and CTAs
> - Introduces new [SponsorCard.astro](https://github.com/T3-Content/t3.gg/pull/52/files#diff-6c662ec8894ea0b484c150e55b04ba2942eaaaaa456b2c9c5f986ba864e9bd72) and [SponsorLogo.astro](https://github.com/T3-Content/t3.gg/pull/52/files#diff-4034307e53ee18ef91a87742f440ca61e1ffb9894048330f10f634c22710d6ef) components; refactors [SponsorGridSection.astro](https://github.com/T3-Content/t3.gg/pull/52/files#diff-69c025ccc681337e707870502fb1e2337f4430463c99fd3e9c0bac230e094208) to delegate rendering to these components
> - Refactors [sponsors.ts](https://github.com/T3-Content/t3.gg/pull/52/files#diff-e780692c0069fb6ed97ec20c91eddb8cfd5bb164900c7d16671c4aa6e1fee081) into a typed model with tiers, categories, slugs, and builder functions
> - Adds a social links footer to the homepage and suppresses the global footer on the homepage; adds YouTube to social links site-wide
> - Platinum sponsor cards gain an animated gradient border via new CSS in [global.css](https://github.com/T3-Content/t3.gg/pull/52/files#diff-cb9b22d8ae64eadf8a62cff07d4ec807587e4487714aadabe9681a485a8f0c95)
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8d88ce4. 10 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->